### PR TITLE
Adjust header name display

### DIFF
--- a/src/components/header/UserDropdown.tsx
+++ b/src/components/header/UserDropdown.tsx
@@ -2,10 +2,12 @@ import { useState } from "react";
 import { DropdownItem } from "../ui/dropdown/DropdownItem";
 import { Dropdown } from "../ui/dropdown/Dropdown";
 import { useNavigate } from "react-router-dom";
+import { useUser } from "@/hooks/useUser";
 
 export default function UserDropdown() {
   const [isOpen, setIsOpen] = useState(false);
   const navigate = useNavigate();
+  const user = useUser();
   function toggleDropdown() {
     setIsOpen(!isOpen);
   }
@@ -23,7 +25,9 @@ export default function UserDropdown() {
           <img src="/images/user/owner.jpg" alt="User" />
         </span>
 
-        <span className="block mr-1 font-medium text-theme-sm">Musharof</span>
+        <span className="block mr-1 font-medium text-theme-sm">
+          {user?.firstName}
+        </span>
         <svg
           className={`stroke-gray-500 dark:stroke-gray-400 transition-transform duration-200 ${
             isOpen ? "rotate-180" : ""
@@ -51,10 +55,10 @@ export default function UserDropdown() {
       >
         <div>
           <span className="block font-medium text-gray-700 text-theme-sm dark:text-gray-400">
-            Musharof Chowdhury
+            {user?.fullName}
           </span>
           <span className="mt-0.5 block text-theme-xs text-gray-500 dark:text-gray-400">
-            randomuser@pimjo.com
+            {user?.email}
           </span>
         </div>
 

--- a/src/layout/AppHeader.tsx
+++ b/src/layout/AppHeader.tsx
@@ -57,9 +57,6 @@ const AppHeader: React.FC = () => {
           <div className="flex items-center gap-2 2xsm:gap-3">
             <ThemeToggleButton />
             <NotificationDropdown />
-            <span className="hidden sm:inline-block text-sm font-medium text-gray-700 dark:text-gray-200">
-              {user?.firstName} {user?.lastName}
-            </span>
           </div>
           <UserDropdown />
         </div>


### PR DESCRIPTION
## Summary
- trim extra name span from AppHeader
- reference user data in UserDropdown
- show only first name in toggle, full name in dropdown

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find type definition file for 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685041887ca48330a0341aacc3e73bc6